### PR TITLE
Add mode_32bit argument to board_serial_enable/disable

### DIFF
--- a/mobile.c
+++ b/mobile.c
@@ -131,7 +131,7 @@ void mobile_action_process(struct mobile_adapter *adapter, enum mobile_action ac
     case MOBILE_ACTION_CHANGE_32BIT_MODE:
         mobile_board_serial_disable(_u);
         mode_32bit_change(adapter);
-        mobile_board_serial_enable(_u);
+        mobile_board_serial_enable(_u, adapter->serial.mode_32bit);
         break;
 
     case MOBILE_ACTION_DROP_CONNECTION:
@@ -148,7 +148,7 @@ void mobile_action_process(struct mobile_adapter *adapter, enum mobile_action ac
         mobile_debug_endl(adapter);
 
         mobile_board_time_latch(_u, MOBILE_TIMER_SERIAL);
-        mobile_board_serial_enable(_u);
+        mobile_board_serial_enable(_u, adapter->serial.mode_32bit);
         break;
 
     case MOBILE_ACTION_RESET:
@@ -160,13 +160,13 @@ void mobile_action_process(struct mobile_adapter *adapter, enum mobile_action ac
         adapter->serial.active = false;
 
         mobile_board_time_latch(_u, MOBILE_TIMER_SERIAL);
-        mobile_board_serial_enable(_u);
+        mobile_board_serial_enable(_u, adapter->serial.mode_32bit);
         break;
 
     case MOBILE_ACTION_RESET_SERIAL:
         mobile_board_serial_disable(_u);
         mobile_board_time_latch(_u, MOBILE_TIMER_SERIAL);
-        mobile_board_serial_enable(_u);
+        mobile_board_serial_enable(_u, adapter->serial.mode_32bit);
         break;
 
     default:
@@ -236,5 +236,5 @@ void mobile_init(struct mobile_adapter *adapter, void *user, const struct mobile
     mobile_commands_init(adapter);
     mobile_serial_init(adapter);
     mobile_dns_init(adapter);
-    mobile_board_serial_enable(user);
+    mobile_board_serial_enable(user, adapter->serial.mode_32bit);
 }

--- a/mobile.c
+++ b/mobile.c
@@ -129,13 +129,13 @@ void mobile_action_process(struct mobile_adapter *adapter, enum mobile_action ac
         break;
 
     case MOBILE_ACTION_CHANGE_32BIT_MODE:
-        mobile_board_serial_disable(_u);
+        mobile_board_serial_disable(_u, adapter->serial.mode_32bit);
         mode_32bit_change(adapter);
         mobile_board_serial_enable(_u, adapter->serial.mode_32bit);
         break;
 
     case MOBILE_ACTION_DROP_CONNECTION:
-        mobile_board_serial_disable(_u);
+        mobile_board_serial_disable(_u, adapter->serial.mode_32bit);
 
         // "Emulate" an end session.
         mobile_serial_init(adapter);
@@ -152,7 +152,7 @@ void mobile_action_process(struct mobile_adapter *adapter, enum mobile_action ac
         break;
 
     case MOBILE_ACTION_RESET:
-        mobile_board_serial_disable(_u);
+        mobile_board_serial_disable(_u, adapter->serial.mode_32bit);
 
         adapter->commands.mode_32bit = false;
         mode_32bit_change(adapter);
@@ -164,7 +164,7 @@ void mobile_action_process(struct mobile_adapter *adapter, enum mobile_action ac
         break;
 
     case MOBILE_ACTION_RESET_SERIAL:
-        mobile_board_serial_disable(_u);
+        mobile_board_serial_disable(_u, adapter->serial.mode_32bit);
         mobile_board_time_latch(_u, MOBILE_TIMER_SERIAL);
         mobile_board_serial_enable(_u, adapter->serial.mode_32bit);
         break;

--- a/mobile.h
+++ b/mobile.h
@@ -134,7 +134,7 @@ void mobile_board_debug_log(void *user, const char *line);
 // was called. If mobile_transfer() and mobile_loop() are implemented as
 // separate threads, a mutex-like locking mechanism may be used to accomplish
 // this.
-void mobile_board_serial_disable(void *user);
+void mobile_board_serial_disable(void *user, bool mode_32bit);
 
 // mobile_board_serial_enable - Enable serial communications
 //

--- a/mobile.h
+++ b/mobile.h
@@ -140,7 +140,7 @@ void mobile_board_serial_disable(void *user);
 //
 // Exact opposite of mobile_board_serial_disable(). This function indicates
 // mobile_transfer() may be called again, resuming communications.
-void mobile_board_serial_enable(void *user);
+void mobile_board_serial_enable(void *user, bool mode_32bit);
 
 // mobile_board_config_read - Read from the configuration data
 //

--- a/weak_defs.c
+++ b/weak_defs.c
@@ -18,7 +18,7 @@ struct mobile_packet;
 
 A_WEAK void mobile_board_debug_log(A_UNUSED void *user, A_UNUSED const char *line) {}
 A_WEAK void mobile_board_serial_disable(A_UNUSED void *user) {}
-A_WEAK void mobile_board_serial_enable(A_UNUSED void *user) {}
+A_WEAK void mobile_board_serial_enable(A_UNUSED void *user, A_UNUSED bool mode_32bit) {}
 A_WEAK bool mobile_board_config_read(A_UNUSED void *user, void *dest, A_UNUSED uintptr_t offset, size_t size)
 {
     memset(dest, 0xFF, size);

--- a/weak_defs.c
+++ b/weak_defs.c
@@ -17,7 +17,7 @@ struct mobile_packet;
 #ifdef A_WEAK
 
 A_WEAK void mobile_board_debug_log(A_UNUSED void *user, A_UNUSED const char *line) {}
-A_WEAK void mobile_board_serial_disable(A_UNUSED void *user) {}
+A_WEAK void mobile_board_serial_disable(A_UNUSED void *user, A_UNUSED bool mode_32bit) {}
 A_WEAK void mobile_board_serial_enable(A_UNUSED void *user, A_UNUSED bool mode_32bit) {}
 A_WEAK bool mobile_board_config_read(A_UNUSED void *user, void *dest, A_UNUSED uintptr_t offset, size_t size)
 {


### PR DESCRIPTION
Seems like a fairly natural way to instruct hardware to change mode

Adding the argument to serial_disable as well may be helpful for some implementations to avoid duplicating state