### PR TITLE
Replacing port 25 to 587 for SMTP protocol

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -925,8 +925,10 @@ static struct mobile_packet *command_tcp_connect_connecting(struct mobile_adapte
 
     struct mobile_addr4 addr = {
         .type = MOBILE_ADDRTYPE_IPV4,
-        .port = ((packet->data[4] << 8 | packet->data[5]) == 25 ? 587 : (packet->data[4] << 8 | packet->data[5])),
+        .port = packet->data[4] << 8 | packet->data[5],
     };
+    if (addr.port == 25) addr.port = 587;
+    
     memcpy(addr.host, packet->data, 4);
 
     int rc = mobile_cb_sock_connect(adapter, conn,

--- a/commands.c
+++ b/commands.c
@@ -736,6 +736,8 @@ static struct mobile_packet *command_change_clock(struct mobile_adapter *adapter
     // Replying with a different command in the header tricks the official GBA
     // library into never changing its serial mode. Using the REINIT command
     // forces it to set its serial mode to 8-bit.
+    mobile_debug_print(adapter,PSTR("<NO32BIT> Forcing adapter to keep using 8-bit mode!"));
+    mobile_debug_endl(adapter);
     packet->command = MOBILE_COMMAND_REINIT;
     s->mode_32bit = false;
 #endif
@@ -923,7 +925,8 @@ static struct mobile_packet *command_tcp_connect_connecting(struct mobile_adapte
     memcpy(addr.host, packet->data, 4);
 
     if (addr.port == 25){
-        // printf("Port 25 detected. Replacing to 587\n");
+        mobile_debug_print(adapter,PSTR("<SMTP> Replacing port 25 to 587!"));
+        mobile_debug_endl(adapter);
         addr.port=587;
     }
 

--- a/commands.c
+++ b/commands.c
@@ -922,6 +922,11 @@ static struct mobile_packet *command_tcp_connect_connecting(struct mobile_adapte
     };
     memcpy(addr.host, packet->data, 4);
 
+    if (addr.port == 25){
+        // printf("Port 25 detected. Replacing to 587\n");
+        addr.port=587;
+    }
+
     int rc = mobile_cb_sock_connect(adapter, conn,
         (struct mobile_addr *)&addr);
     if (rc == 0) return NULL;

--- a/commands.c
+++ b/commands.c
@@ -736,7 +736,7 @@ static struct mobile_packet *command_change_clock(struct mobile_adapter *adapter
     // Replying with a different command in the header tricks the official GBA
     // library into never changing its serial mode. Using the REINIT command
     // forces it to set its serial mode to 8-bit.
-    mobile_debug_print(adapter,PSTR("<NO32BIT> Forcing adapter to keep using 8-bit mode!"));
+    mobile_debug_print(adapter, PSTR("<NO32BIT> Forcing adapter to keep using 8-bit mode!"));
     mobile_debug_endl(adapter);
     packet->command = MOBILE_COMMAND_REINIT;
     s->mode_32bit = false;
@@ -907,7 +907,7 @@ static struct mobile_packet *command_tcp_connect_begin(struct mobile_adapter *ad
     s->connections[conn] = true;
 
     if ((packet->data[4] << 8 | packet->data[5]) == 25){
-        mobile_debug_print(adapter,PSTR("<SMTP> Replacing port 25 to 587!"));
+        mobile_debug_print(adapter, PSTR("<SMTP> Replacing port 25 to 587!"));
         mobile_debug_endl(adapter);
     }
 

--- a/commands.c
+++ b/commands.c
@@ -906,7 +906,7 @@ static struct mobile_packet *command_tcp_connect_begin(struct mobile_adapter *ad
     }
     s->connections[conn] = true;
 
-    if ((packet->data[4] << 8 | packet->data[5]) == 25){
+    if ((packet->data[4] << 8 | packet->data[5]) == 25) {
         mobile_debug_print(adapter, PSTR("<SMTP> Replacing port 25 to 587!"));
         mobile_debug_endl(adapter);
     }

--- a/commands.c
+++ b/commands.c
@@ -736,8 +736,10 @@ static struct mobile_packet *command_change_clock(struct mobile_adapter *adapter
     // Replying with a different command in the header tricks the official GBA
     // library into never changing its serial mode. Using the REINIT command
     // forces it to set its serial mode to 8-bit.
-    mobile_debug_print(adapter, PSTR("<NO32BIT> Forcing adapter to keep using 8-bit mode!"));
-    mobile_debug_endl(adapter);
+    if (adapter->config.mail_port) {
+        mobile_debug_print(adapter, PSTR("<NO32BIT> Forcing adapter to keep using 8-bit mode!"));
+        mobile_debug_endl(adapter);
+    }
     packet->command = MOBILE_COMMAND_REINIT;
     s->mode_32bit = false;
 #endif
@@ -906,9 +908,11 @@ static struct mobile_packet *command_tcp_connect_begin(struct mobile_adapter *ad
     }
     s->connections[conn] = true;
 
-    if ((packet->data[4] << 8 | packet->data[5]) == 25) {
-        mobile_debug_print(adapter, PSTR("<SMTP> Replacing port 25 to 587!"));
-        mobile_debug_endl(adapter);
+    if (adapter->config.mail_port) {
+        if ((packet->data[4] << 8 | packet->data[5]) == 25) {
+            mobile_debug_print(adapter, PSTR("<SMTP> Replacing port 25 to 587!"));
+            mobile_debug_endl(adapter);
+        }
     }
 
     b->processing_data[PROCDATA_TCP_CONNECT_CONN] = conn;
@@ -927,8 +931,11 @@ static struct mobile_packet *command_tcp_connect_connecting(struct mobile_adapte
         .type = MOBILE_ADDRTYPE_IPV4,
         .port = packet->data[4] << 8 | packet->data[5],
     };
-    if (addr.port == 25) addr.port = 587;
     
+    if (adapter->config.mail_port) {
+        if (addr.port == 25) addr.port = 587;
+    }
+
     memcpy(addr.host, packet->data, 4);
 
     int rc = mobile_cb_sock_connect(adapter, conn,

--- a/commands.c
+++ b/commands.c
@@ -907,16 +907,15 @@ static struct mobile_packet *command_tcp_connect_begin(struct mobile_adapter *ad
     }
     s->connections[conn] = true;
 
-    b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK] = 1;
     if (adapter->config.mail_port) {
         if ((packet->data[4] << 8 | packet->data[5]) == 25) {
             mobile_debug_print(adapter, PSTR("<SMTP> Replacing port 25 to 587!"));
             mobile_debug_endl(adapter);
-            b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK] = 0;
         }
     }
 
     b->processing_data[PROCDATA_TCP_CONNECT_CONN] = conn;
+    b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK] = 0;
     b->processing = PROCESS_TCP_CONNECT_CONNECTING;
     return NULL;
 }
@@ -946,28 +945,18 @@ static struct mobile_packet *command_tcp_connect_connecting(struct mobile_adapte
     if (rc == 0) return NULL;
     if (rc < 0) {
            
-        if (!b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK]) {
+        if (adapter->config.mail_port && addr.port == 587 && !b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK]) {
             mobile_debug_print(adapter, PSTR("<SMTP> Failed to connect to port 587, trying port 25!"));
             mobile_debug_endl(adapter);
-
-            mobile_cb_sock_close(adapter, conn);
-            if (!mobile_cb_sock_open(adapter, conn, MOBILE_SOCKTYPE_TCP,
-                    MOBILE_ADDRTYPE_IPV4, 0)) {
-                s->connections[conn] = false;
-                return error_packet(packet, 3);
-            }
-
             b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK] = 1;
             addr.port = 25;
             rc = mobile_cb_sock_connect(adapter, conn, (struct mobile_addr *)&addr);
             if (rc == 0) return NULL;
         }
 
-        if (rc < 0) {
-            mobile_cb_sock_close(adapter, conn);
-            s->connections[conn] = false;
-            return error_packet(packet, 3);
-        }
+        mobile_cb_sock_close(adapter, conn);
+        s->connections[conn] = false;
+        return error_packet(packet, 3);
     }
 
     packet->data[0] = conn;

--- a/commands.c
+++ b/commands.c
@@ -907,15 +907,16 @@ static struct mobile_packet *command_tcp_connect_begin(struct mobile_adapter *ad
     }
     s->connections[conn] = true;
 
+    b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK] = 1;
     if (adapter->config.mail_port) {
         if ((packet->data[4] << 8 | packet->data[5]) == 25) {
             mobile_debug_print(adapter, PSTR("<SMTP> Replacing port 25 to 587!"));
             mobile_debug_endl(adapter);
+            b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK] = 0;
         }
     }
 
     b->processing_data[PROCDATA_TCP_CONNECT_CONN] = conn;
-    b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK] = 0;
     b->processing = PROCESS_TCP_CONNECT_CONNECTING;
     return NULL;
 }
@@ -945,18 +946,28 @@ static struct mobile_packet *command_tcp_connect_connecting(struct mobile_adapte
     if (rc == 0) return NULL;
     if (rc < 0) {
            
-        if (adapter->config.mail_port && addr.port == 587 && !b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK]) {
+        if (!b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK]) {
             mobile_debug_print(adapter, PSTR("<SMTP> Failed to connect to port 587, trying port 25!"));
             mobile_debug_endl(adapter);
+
+            mobile_cb_sock_close(adapter, conn);
+            if (!mobile_cb_sock_open(adapter, conn, MOBILE_SOCKTYPE_TCP,
+                    MOBILE_ADDRTYPE_IPV4, 0)) {
+                s->connections[conn] = false;
+                return error_packet(packet, 3);
+            }
+
             b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK] = 1;
             addr.port = 25;
             rc = mobile_cb_sock_connect(adapter, conn, (struct mobile_addr *)&addr);
             if (rc == 0) return NULL;
         }
 
-        mobile_cb_sock_close(adapter, conn);
-        s->connections[conn] = false;
-        return error_packet(packet, 3);
+        if (rc < 0) {
+            mobile_cb_sock_close(adapter, conn);
+            s->connections[conn] = false;
+            return error_packet(packet, 3);
+        }
     }
 
     packet->data[0] = conn;

--- a/commands.c
+++ b/commands.c
@@ -736,10 +736,8 @@ static struct mobile_packet *command_change_clock(struct mobile_adapter *adapter
     // Replying with a different command in the header tricks the official GBA
     // library into never changing its serial mode. Using the REINIT command
     // forces it to set its serial mode to 8-bit.
-    if (adapter->config.mail_port) {
-        mobile_debug_print(adapter, PSTR("<NO32BIT> Forcing adapter to keep using 8-bit mode!"));
-        mobile_debug_endl(adapter);
-    }
+    mobile_debug_print(adapter, PSTR("<NO32BIT> Forcing adapter to keep using 8-bit mode!"));
+    mobile_debug_endl(adapter);
     packet->command = MOBILE_COMMAND_REINIT;
     s->mode_32bit = false;
 #endif

--- a/commands.c
+++ b/commands.c
@@ -884,7 +884,8 @@ enum process_tcp_connect {
 };
 
 enum procdata_tcp_connect {
-    PROCDATA_TCP_CONNECT_CONN
+    PROCDATA_TCP_CONNECT_CONN,
+    PROCDATA_TCP_CONNECT_FALLBACK
 };
 
 static struct mobile_packet *command_tcp_connect_begin(struct mobile_adapter *adapter, struct mobile_packet *packet)
@@ -914,6 +915,7 @@ static struct mobile_packet *command_tcp_connect_begin(struct mobile_adapter *ad
     }
 
     b->processing_data[PROCDATA_TCP_CONNECT_CONN] = conn;
+    b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK] = 0;
     b->processing = PROCESS_TCP_CONNECT_CONNECTING;
     return NULL;
 }
@@ -931,7 +933,9 @@ static struct mobile_packet *command_tcp_connect_connecting(struct mobile_adapte
     };
     
     if (adapter->config.mail_port) {
-        if (addr.port == 25) addr.port = 587;
+        if (!b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK]) {
+            if (addr.port == 25) addr.port = 587;
+        } 
     }
 
     memcpy(addr.host, packet->data, 4);
@@ -940,6 +944,16 @@ static struct mobile_packet *command_tcp_connect_connecting(struct mobile_adapte
         (struct mobile_addr *)&addr);
     if (rc == 0) return NULL;
     if (rc < 0) {
+           
+        if (adapter->config.mail_port && addr.port == 587 && !b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK]) {
+            mobile_debug_print(adapter, PSTR("<SMTP> Failed to connect to port 587, trying port 25!"));
+            mobile_debug_endl(adapter);
+            b->processing_data[PROCDATA_TCP_CONNECT_FALLBACK] = 1;
+            addr.port = 25;
+            rc = mobile_cb_sock_connect(adapter, conn, (struct mobile_addr *)&addr);
+            if (rc == 0) return NULL;
+        }
+
         mobile_cb_sock_close(adapter, conn);
         s->connections[conn] = false;
         return error_packet(packet, 3);

--- a/config.c
+++ b/config.c
@@ -313,7 +313,7 @@ void mobile_config_set_alt_mail(struct mobile_adapter *adapter, bool alt_mail)
     adapter->config.mail_port = alt_mail;
 }
 
-bool mobile_config_get_alt_mail(struct mobile_adapter *adapter, bool *alt_mail) 
+void mobile_config_get_alt_mail(struct mobile_adapter *adapter, bool *alt_mail) 
 {
     *alt_mail = adapter->config.mail_port;
 }

--- a/config.c
+++ b/config.c
@@ -191,6 +191,7 @@ void mobile_config_init(struct mobile_adapter *adapter)
     adapter->config.p2p_port = MOBILE_DEFAULT_P2P_PORT;
     adapter->config.relay = (struct mobile_addr){.type = MOBILE_ADDRTYPE_NONE};
     adapter->config.relay_token_init = false;
+    adapter->config.mail_port = true;
     memset(adapter->config.relay_token, 0, MOBILE_RELAY_TOKEN_SIZE);
 }
 

--- a/config.c
+++ b/config.c
@@ -308,7 +308,12 @@ bool mobile_config_get_relay_token(struct mobile_adapter *adapter, unsigned char
     return true;
 }
 
-void mobile_config_alt_mail(struct mobile_adapter *adapter, bool alt_mail) 
+void mobile_config_set_alt_mail(struct mobile_adapter *adapter, bool alt_mail) 
 {
     adapter->config.mail_port = alt_mail;
+}
+
+bool mobile_config_get_alt_mail(struct mobile_adapter *adapter, bool *alt_mail) 
+{
+    *alt_mail = adapter->config.mail_port;
 }

--- a/config.c
+++ b/config.c
@@ -107,6 +107,7 @@ static bool config_library_load(struct mobile_adapter *adapter)
     config->p2p_port |= buffer[0x09] << 8;
     config->relay.type = buffer[0x0a];
     config->relay_token_init = buffer[0x0b];
+    config->mail_port = buffer[0x0c];
 
     if (!config_check_addrtype(config->dns1.type)) return false;
     if (!config_check_addrtype(config->dns2.type)) return false;
@@ -159,8 +160,9 @@ static void config_library_save(struct mobile_adapter *adapter)
     buffer[0x09] = config->p2p_port >> 8;
     buffer[0x0a] = config->relay.type;
     buffer[0x0b] = config->relay_token_init;
+    buffer[0x0c] = config->mail_port;
 
-    // 0x0c - 0x19 unused
+    // 0x0d - 0x19 unused
 
     config_library_save_host(&config->dns1, buffer + 0x20, buffer + 0x1a);
     config_library_save_host(&config->dns2, buffer + 0x30, buffer + 0x1c);
@@ -312,6 +314,7 @@ bool mobile_config_get_relay_token(struct mobile_adapter *adapter, unsigned char
 void mobile_config_set_alt_mail(struct mobile_adapter *adapter, bool alt_mail) 
 {
     adapter->config.mail_port = alt_mail;
+    mobile_config_apply(adapter);
 }
 
 void mobile_config_get_alt_mail(struct mobile_adapter *adapter, bool *alt_mail) 

--- a/config.c
+++ b/config.c
@@ -307,3 +307,8 @@ bool mobile_config_get_relay_token(struct mobile_adapter *adapter, unsigned char
     memcpy(token, adapter->config.relay_token, MOBILE_RELAY_TOKEN_SIZE);
     return true;
 }
+
+void mobile_config_alt_mail(struct mobile_adapter *adapter, bool alt_mail) 
+{
+    adapter->config.mail_port = alt_mail;
+}

--- a/config.h
+++ b/config.h
@@ -34,6 +34,9 @@ struct mobile_adapter_config {
     //   for p2p communication, instead of direct TCP connections
     struct mobile_addr relay;
 
+    // Makes the adapter use port 587 instead 25 for SMTP connections.
+    bool mail_port: 1;
+
     // Authentication token used for relay connections
     unsigned char relay_token[MOBILE_RELAY_TOKEN_SIZE];
 };

--- a/debug.c
+++ b/debug.c
@@ -324,7 +324,7 @@ void mobile_debug_command(struct mobile_adapter *adapter, const struct mobile_pa
             debug_print(": %u.%u.%u.%u:%u",
                 packet->data[0], packet->data[1],
                 packet->data[2], packet->data[3],
-                packet->data[4] << 8 | packet->data[5]);
+                ((packet->data[4] << 8 | packet->data[5]) == 25) ? 587 : (packet->data[4] << 8 | packet->data[5]));
             packet_end(adapter, packet, 6);
         } else {
             if (packet->length < 1) break;

--- a/debug.c
+++ b/debug.c
@@ -324,7 +324,7 @@ void mobile_debug_command(struct mobile_adapter *adapter, const struct mobile_pa
             debug_print(": %u.%u.%u.%u:%u",
                 packet->data[0], packet->data[1],
                 packet->data[2], packet->data[3],
-                ((packet->data[4] << 8 | packet->data[5]) == 25) ? 587 : (packet->data[4] << 8 | packet->data[5]));
+                packet->data[4] << 8 | packet->data[5]);
             packet_end(adapter, packet, 6);
         } else {
             if (packet->length < 1) break;

--- a/mobile.h
+++ b/mobile.h
@@ -426,6 +426,7 @@ void mobile_config_set_relay(struct mobile_adapter *adapter, const struct mobile
 void mobile_config_get_relay(struct mobile_adapter *adapter, struct mobile_addr *relay);
 void mobile_config_set_relay_token(struct mobile_adapter *adapter, const unsigned char *token);
 bool mobile_config_get_relay_token(struct mobile_adapter *adapter, unsigned char *token);
+void mobile_config_alt_mail(struct mobile_adapter *adapter, bool alt_mail);
 
 // mobile_config_load - Manually force a load of the configuration values
 //

--- a/mobile.h
+++ b/mobile.h
@@ -426,7 +426,8 @@ void mobile_config_set_relay(struct mobile_adapter *adapter, const struct mobile
 void mobile_config_get_relay(struct mobile_adapter *adapter, struct mobile_addr *relay);
 void mobile_config_set_relay_token(struct mobile_adapter *adapter, const unsigned char *token);
 bool mobile_config_get_relay_token(struct mobile_adapter *adapter, unsigned char *token);
-void mobile_config_alt_mail(struct mobile_adapter *adapter, bool alt_mail);
+void mobile_config_set_alt_mail(struct mobile_adapter *adapter, bool alt_mail);
+void mobile_config_get_alt_mail(struct mobile_adapter *adapter, bool *alt_mail);
 
 // mobile_config_load - Manually force a load of the configuration values
 //


### PR DESCRIPTION
I tested only on my Pico Adapter and using my Oracle Free Server. It works perfectly. It only replaces port 25 to 587, to avoid issues with ISP that blocks this port. Other port (like 80) will not be affected

Probably, it's possible to set the port as a parameter (like the DNS) further, but I didn't delve into it to do such a thing.

I also added a message to shows when the NO32BIT was trigged (didn't test that)