### PR TITLE
update P2P synchronisation

### DIFF
--- a/commands.c
+++ b/commands.c
@@ -627,12 +627,11 @@ static struct mobile_packet *command_data(struct mobile_adapter *adapter, struct
         MOBILE_MAX_TRANSFER_SIZE, NULL);
 
     if (recv_size == -2) {
-        mobile_cb_sock_close(adapter, conn);
-        s->connections[conn] = false;
-
         // If connected to the internet, and a disconnect is received, we
         // should inform the game about a remote disconnect.
         if (internet) {
+            mobile_cb_sock_close(adapter, conn);
+            s->connections[conn] = false;
             packet->command = MOBILE_COMMAND_DATA_END;
         }
         packet->length = 1;

--- a/commands.h
+++ b/commands.h
@@ -65,7 +65,6 @@ struct mobile_adapter_commands {
     enum mobile_connection_state state;
     bool connections[MOBILE_MAX_CONNECTIONS];
     bool dns2_use;
-    unsigned char call_packets_sent;
     struct mobile_addr4 dns1;
     struct mobile_addr4 dns2;
 };


### PR DESCRIPTION
the P2P features of Zero Tours only work in one direction at a time, so it won't do to only receive as many packets as are sent; in fact, it seems that this was never the issue with Pokémon. rather, the issue with Pokémon was that it was receiving a low-level error on remote disconnect, which isn't even a detectable state when the connection is over a phone line. rather, we simply stop sending the game data, allowing it to detect the remote disconnect through a timeout or other method which, to reiterate, was necessary in '01/'02 when these games were connecting over a phone line.